### PR TITLE
Fixed crashes if mod is hidden

### DIFF
--- a/ModManagerUI/ModsBox.cs
+++ b/ModManagerUI/ModsBox.cs
@@ -227,7 +227,15 @@ namespace Timberborn.ModsSystemUI
             var installedMods = _installedAddonRepository.All().ToList();
             foreach (Manifest manifest in installedMods)
             {
-                var mod = await ModIo.Client.Games[ModIoGameInfo.GameId].Mods[manifest.ModId].Get();
+                Mod mod;
+                try
+                {
+                    mod = await ModIo.Client.Games[ModIoGameInfo.GameId].Mods[manifest.ModId].Get();
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
                 if (mod.Modfile.Version != manifest.Version &&
                     VersionComparer.IsVersionHigher(mod.Modfile.Version, manifest.Version))
                 {


### PR DESCRIPTION
Added a try catch around the api request in the ModsBox. It would crash on a mod that is removed or hidden. It will now do a general catch and skip it.